### PR TITLE
Release 2.2.13: redis (vul fixes)

### DIFF
--- a/7.0/alpine/Dockerfile
+++ b/7.0/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.16
+FROM alpine:3.21
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN addgroup -S -g 1000 redis && adduser -S -G redis -u 999 redis


### PR DESCRIPTION
Made a new release: ❯ trivy i gcr.io/hasura-ee/redis:7.0.14-alpine3.21

Before:
<img width="1208" alt="image" src="https://github.com/user-attachments/assets/a129c7b2-ff5c-49d8-805a-196fb5a33709" />

After:
<img width="1281" alt="image" src="https://github.com/user-attachments/assets/52ac69ab-4053-4c1b-bcf9-4b8084b4b5fd" />


